### PR TITLE
Improve breakLine handling

### DIFF
--- a/Sources/ZMarkupParser/Core/Processor/MarkupNSAttributedStringVisitor.swift
+++ b/Sources/ZMarkupParser/Core/Processor/MarkupNSAttributedStringVisitor.swift
@@ -196,24 +196,26 @@ extension MarkupNSAttributedStringVisitor {
         let mutableAttributedString = NSMutableAttributedString(attributedString: attributedString)
 
         let totalLength = mutableAttributedString.string.utf16.count
-        mutableAttributedString.enumerateAttribute(.reduceableBreakLine, in: NSMakeRange(0, totalLength)) { reduceableBreakLine, range, _ in
-            if let reduceableBreakLine = reduceableBreakLine as? Bool, reduceableBreakLine == true {
-                if range.length >= 2 {
-                    // remove redundant
-                    mutableAttributedString.replaceCharacters(in: range, with: "\n")
+        if totalLength > 0 {
+            mutableAttributedString.enumerateAttribute(.reduceableBreakLine, in: NSMakeRange(0, totalLength)) { reduceableBreakLine, range, _ in
+                if let reduceableBreakLine = reduceableBreakLine as? Bool, reduceableBreakLine == true {
+                    if range.length >= 2 {
+                        // remove redundant
+                        mutableAttributedString.replaceCharacters(in: range, with: "\n")
+                    }
                 }
             }
-        }
-
-        //prefix break line:
-        var range = NSRange()
-        if mutableAttributedString.attribute(.isBreakLine, at: 0, effectiveRange: &range) != nil {
-            mutableAttributedString.replaceCharacters(in: range, with: "")
-        }
-
-        //suffix break line:
-        if mutableAttributedString.attribute(.isBreakLine, at: mutableAttributedString.string.utf16.count - 1, effectiveRange: &range) != nil {
-            mutableAttributedString.replaceCharacters(in: range, with: "")
+    
+            //prefix break line:
+            var range = NSRange()
+            if mutableAttributedString.attribute(.isBreakLine, at: 0, effectiveRange: &range) != nil {
+                mutableAttributedString.replaceCharacters(in: range, with: "")
+            }
+    
+            //suffix break line:
+            if mutableAttributedString.attribute(.isBreakLine, at: mutableAttributedString.string.utf16.count - 1, effectiveRange: &range) != nil {
+                mutableAttributedString.replaceCharacters(in: range, with: "")
+            }
         }
 
         return mutableAttributedString

--- a/Tests/ZMarkupParserTests/Core/MarkupNSAttributedStringVisitorTests.swift
+++ b/Tests/ZMarkupParserTests/Core/MarkupNSAttributedStringVisitorTests.swift
@@ -103,3 +103,6 @@ final class MarkupNSAttributedStringVisitorTests: XCTestCase {
 private extension NSAttributedString.Key {
     static let reduceableBreakLine: NSAttributedString.Key = .init("reduceableBreakLine")
 }
+private extension NSAttributedString.Key {
+    static let isBreakLine: NSAttributedString.Key = .init("isBreakLine")
+}


### PR DESCRIPTION
### Fix1:

When evaluating container tags (like `div` or `p`) they always have a break line before them. Which in general is what we want. But when the container tag is at the start, this would lead to an empty line before it.

So for example this
```<div>This is one line</div>```
is evaluated as:
```

This is one line
```

instead of (notice that there is to empty line above):
```
This is one line
```

Or more importantly this:
```
<ul>
<li><div>Item</div></li>
<li><div>Item</div></li>
</ul>
```
would create something like this:

- \
Item
- \
Item



### Fix2:


Having something like this `A<br><br><br>B` would be evaluated as:

```
A

B
```
instead of:

```
A



B
```



I hope this is helpful for you :)

**Disclaimer 1:**
I tested my changes with data from the app, where the library is used and I am content that it works as expected.
But I did not run (or fix) any UnitTests because my knowledge of pure library development is limited.

**Disclaimer 2:**
In case Fix 2 breaks intended behaviour, you can just revert my change in this line:
https://github.com/JodliDev/ZMarkupParser/blob/2c6a74edc37678efd888d41c07bcdab7d0500bab/Sources/ZMarkupParser/Core/Processor/MarkupNSAttributedStringVisitor.swift#L23