### PR TITLE
Store the color directly instead of the RGBA values

### DIFF
--- a/Sources/ZMarkupParser/Core/MarkupStyle/MarkupStyleColor.swift
+++ b/Sources/ZMarkupParser/Core/MarkupStyle/MarkupStyleColor.swift
@@ -1,6 +1,6 @@
 //
 //  MarkupStyleColor.swift
-//  
+//
 //
 //  Created by https://zhgchg.li on 2023/2/4.
 //
@@ -13,11 +13,12 @@ import AppKit
 #endif
 
 public struct MarkupStyleColor {
-    let red: Int
-    let green: Int
-    let blue: Int
-    let alpha: CGFloat
-    
+#if canImport(UIKit)
+    let color: UIColor
+#elseif canImport(AppKit)
+    let color: NSColor
+#endif
+       
     init?(red: Int, green: Int, blue: Int, alpha: CGFloat) {
         guard red >= 0 && red <= 255,
               green >= 0 && green <= 255,
@@ -25,11 +26,12 @@ public struct MarkupStyleColor {
               alpha >= 0 && alpha <= 1 else {
             return nil
         }
-        
-        self.red = red
-        self.green = green
-        self.blue = blue
-        self.alpha = alpha
+        #if canImport(UIKit)
+            self.color = UIColor(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: alpha)
+        #elseif canImport(AppKit)
+            self.color = NSColor(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: alpha)
+        #endif
+
     }
     
     public init?(name: MarkupStyleColorName) {
@@ -112,32 +114,23 @@ public struct MarkupStyleColor {
 extension MarkupStyleColor {
     
     public func getColor() -> UIColor {
-        return UIColor(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: alpha)
+        return color
     }
     
     public init(color: UIColor) {
-        let ciColor = CIColor(color: color)
-        self.red = Int(ciColor.red * 255)
-        self.green = Int(ciColor.green * 255)
-        self.blue = Int(ciColor.blue * 255)
-        self.alpha = ciColor.alpha
+        self.color = color
     }
 }
 
 #elseif canImport(AppKit)
 
 extension MarkupStyleColor {
-
     public func getColor() -> NSColor {
-        return NSColor(red: CGFloat(red)/255.0, green: CGFloat(green)/255.0, blue: CGFloat(blue)/255.0, alpha: alpha)
+        return color
     }
     
     public init(color: NSColor) {
-        let ciColor = CIColor(color: color)
-        self.red = Int((ciColor?.red ?? 0) * 255)
-        self.green = Int((ciColor?.green ?? 0) * 255)
-        self.blue = Int((ciColor?.blue ?? 0) * 255)
-        self.alpha = ciColor?.alpha ?? 1
+        self.color = color
     }
 }
 

--- a/Tests/ZMarkupParserTests/Core/MarkupStyleColorTests.swift
+++ b/Tests/ZMarkupParserTests/Core/MarkupStyleColorTests.swift
@@ -22,11 +22,11 @@ final class MarkupStyleColorTests: XCTestCase {
         for colorName in allCases {
             let sponsor = MarkupStyleSponsorColor.pinkoi(colorName)
             
-            let markupStyleColor = MarkupStyleColor(sponsor: sponsor)
-            XCTAssertEqual(markupStyleColor?.red, colorName.rgb.0)
-            XCTAssertEqual(markupStyleColor?.green, colorName.rgb.1)
-            XCTAssertEqual(markupStyleColor?.blue, colorName.rgb.2)
-            XCTAssertEqual(markupStyleColor?.alpha, 1)
+            let markupStyleColor = MarkupStyleColor(sponsor: sponsor)?.getColor()
+            XCTAssertNotNil(markupStyleColor)
+            
+            let comparison = MarkupStyleColor(red: colorName.rgb.0, green: colorName.rgb.1, blue: colorName.rgb.2, alpha: 1)?.getColor()
+            XCTAssertTrue(markupStyleColor!.isEqual(comparison!))
         }
     }
     
@@ -34,23 +34,23 @@ final class MarkupStyleColorTests: XCTestCase {
         let allCases = MarkupStyleVendorColor.PinkoiColor.allCases
         for colorName in allCases {
             let vendor = MarkupStyleVendorColor.pinkoi(colorName)
+                        
+            let markupStyleColor = MarkupStyleColor(vendor: vendor)?.getColor()
+            XCTAssertNotNil(markupStyleColor)
             
-            let markupStyleColor = MarkupStyleColor(vendor: vendor)
-            XCTAssertEqual(markupStyleColor?.red, colorName.rgb.0)
-            XCTAssertEqual(markupStyleColor?.green, colorName.rgb.1)
-            XCTAssertEqual(markupStyleColor?.blue, colorName.rgb.2)
-            XCTAssertEqual(markupStyleColor?.alpha, 1)
+            let comparison = MarkupStyleColor(red: colorName.rgb.0, green: colorName.rgb.1, blue: colorName.rgb.2, alpha: 1)?.getColor()
+            XCTAssertTrue(markupStyleColor!.isEqual(comparison!))
         }
     }
     
     func testInitStyleFromColorName() throws {
         let allCases = MarkupStyleColorName.allCases
         for colorName in allCases {
-            let markupStyleColor = MarkupStyleColor(name: colorName)
-            XCTAssertEqual(markupStyleColor?.red, colorName.rgb.0)
-            XCTAssertEqual(markupStyleColor?.green, colorName.rgb.1)
-            XCTAssertEqual(markupStyleColor?.blue, colorName.rgb.2)
-            XCTAssertEqual(markupStyleColor?.alpha, 1)
+            let markupStyleColor = MarkupStyleColor(name: colorName)?.getColor()
+            XCTAssertNotNil(markupStyleColor)
+            
+            let comparison = MarkupStyleColor(red: colorName.rgb.0, green: colorName.rgb.1, blue: colorName.rgb.2, alpha: 1)?.getColor()
+            XCTAssertTrue(markupStyleColor!.isEqual(comparison!))
         }
     }
 

--- a/Tests/ZMarkupParserTests/HTML/HTMLTagStyleAttributeToMarkupStyleVisitorTests.swift
+++ b/Tests/ZMarkupParserTests/HTML/HTMLTagStyleAttributeToMarkupStyleVisitorTests.swift
@@ -20,22 +20,22 @@ final class HTMLTagStyleAttributeToMarkupStyleVisitorTests: XCTestCase {
     
     func testColorHTMLTagStyleAttribute() {
         let visitor = HTMLTagStyleAttributeToMarkupStyleVisitor(value: "#ff0000")
-        let markupStyle = visitor.visit(ColorHTMLTagStyleAttribute())
+        let markupColor = visitor.visit(ColorHTMLTagStyleAttribute())?.foregroundColor?.getColor()
+        XCTAssertNotNil(markupColor)
         
-        XCTAssertEqual(markupStyle?.foregroundColor?.red, MarkupStyleColor(string: "#ff0000")?.red)
-        XCTAssertEqual(markupStyle?.foregroundColor?.green, MarkupStyleColor(string: "#ff0000")?.green)
-        XCTAssertEqual(markupStyle?.foregroundColor?.blue, MarkupStyleColor(string: "#ff0000")?.blue)
-        XCTAssertEqual(markupStyle?.foregroundColor?.alpha, MarkupStyleColor(string: "#ff0000")?.alpha)
+        let comparisonColor = MarkupStyleColor(string: "#ff0000")?.getColor()
+        XCTAssertNotNil(comparisonColor)
+        XCTAssertTrue(markupColor!.isEqual(comparisonColor))
     }
     
     func testBackgroundColorHTMLTagStyleAttribute() {
         let visitor = HTMLTagStyleAttributeToMarkupStyleVisitor(value: "#ff0000")
-        let markupStyle = visitor.visit(BackgroundColorHTMLTagStyleAttribute())
-        
-        XCTAssertEqual(markupStyle?.backgroundColor?.red, MarkupStyleColor(string: "#ff0000")?.red)
-        XCTAssertEqual(markupStyle?.backgroundColor?.green, MarkupStyleColor(string: "#ff0000")?.green)
-        XCTAssertEqual(markupStyle?.backgroundColor?.blue, MarkupStyleColor(string: "#ff0000")?.blue)
-        XCTAssertEqual(markupStyle?.backgroundColor?.alpha, MarkupStyleColor(string: "#ff0000")?.alpha)
+        let markupColor = visitor.visit(BackgroundColorHTMLTagStyleAttribute())?.backgroundColor?.getColor()
+        XCTAssertNotNil(markupColor)
+
+        let comparisonColor = MarkupStyleColor(string: "#ff0000")?.getColor()
+        XCTAssertNotNil(comparisonColor)
+        XCTAssertTrue(markupColor!.isEqual(comparisonColor))
     }
     
     func testFontSizeHTMLTagStyleAttribute() {


### PR DESCRIPTION
Currently, `MarkupStyleColor` stores the RGBA values directly, which doesn't work with dynamic colors, so toggling from white mode to dark mode leaves the text dark and illegible.

This PR changes `MarkupStyleColor` to store a provided `UIColor` or `NSColor` directly, rather than converting it to RGBA.