### PR TITLE
Add support for custom attributes containing hyphens

### DIFF
--- a/Sources/ZMarkupParser/HTML/Processor/HTMLStringToParsedResultProcessor.swift
+++ b/Sources/ZMarkupParser/HTML/Processor/HTMLStringToParsedResultProcessor.swift
@@ -26,12 +26,12 @@ final class HTMLStringToParsedResultProcessor: ParserProcessor {
     // e.g 3. </span>
     // selfClosingTag = /
     // tagName = span
-    static let htmlTagRegexPattern: String = #"<(?:(?<closeTag>\/)?(?<tagName>[A-Za-z0-9]+)(?<tagAttributes>(?:\s*(\w+)\s*=\s*(["|']).*?\5)*)\s*(?<selfClosingTag>\/)?>)"#
+    static let htmlTagRegexPattern: String = #"<(?:(?<closeTag>\/)?(?<tagName>[A-Za-z0-9]+)(?<tagAttributes>(?:\s*([\w\-]+)\s*=\s*(["|']).*?\5)*)\s*(?<selfClosingTag>\/)?>)"#
     
     // e.g. href="https://zhgchg.li"
     // name = href
     // value = https://zhgchg.li
-    static let htmlTagAttributesRegexPattern: String = #"\s*(?<name>(?:\w+))\s*={1}\s*(["|']){1}(?<value>.*?)\2\s*"#
+    static let htmlTagAttributesRegexPattern: String = #"\s*(?<name>(?:[\w\-]+))\s*={1}\s*(["|']){1}(?<value>.*?)\2\s*"#
     
     // will match:
     // <!--Test--> / <\!DOCTYPE html> / ` \n `

--- a/Tests/ZMarkupParserTests/HTML/HTMLStringToParsedResultProcessorTests.swift
+++ b/Tests/ZMarkupParserTests/HTML/HTMLStringToParsedResultProcessorTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 final class HTMLStringToParsedResultProcessorTests: XCTestCase {
     func testNormalProcess() {
-        let result = HTMLStringToParsedResultProcessor().process(from: NSAttributedString(string: "Test<a href=\"https://zhgchg.li/about?g=f#hey\" style=\"color:red\">Hello<b>ssss</a>Zhg</b>chgli<br>.<br/>C<br />B"))
+        let result = HTMLStringToParsedResultProcessor().process(from: NSAttributedString(string: "Test<a href=\"https://zhgchg.li/about?g=f#hey\" style=\"color:red\" custom-attribute=\"true\">Hello<b>ssss</a>Zhg</b>chgli<br>.<br/>C<br />B"))
         let items = result.items
         XCTAssertEqual(items.count, 15, "Should have 15 elements.")
         XCTAssertEqual(result.needFormatter, true, "Should have need formatter.")
@@ -27,9 +27,10 @@ final class HTMLStringToParsedResultProcessorTests: XCTestCase {
             case 1:
                 if case let HTMLParsedResult.start(startItem) = item {
                     XCTAssertEqual(startItem.tagName, "a", "expected `a` tag at index:\(index).")
-                    XCTAssertEqual(startItem.attributes?.count, 2, "expected 2 attributes in `a` tag at index:\(index).")
+                    XCTAssertEqual(startItem.attributes?.count, 3, "expected 3 attributes in `a` tag at index:\(index).")
                     XCTAssertEqual(startItem.attributes?["href"], "https://zhgchg.li/about?g=f#hey", "expected  href attribute in `a` tag at index:\(index).")
                     XCTAssertEqual(startItem.attributes?["style"], "color:red", "expected  style attribute in `a` tag at index:\(index).")
+                    XCTAssertEqual(startItem.attributes?["custom-attribute"], "true", "expected custom-attribute attribute in `a` tag at index:\(index).")
                 } else{
                     XCTFail("expected a tag at index:\(index).")
                 }


### PR DESCRIPTION
If a HTML tag has an attribute containing one or more `-`, it is currently ignored.  
Hyphens are often used for custom attributes, and our CMS inserts such attributes in tags, such as:

```
<a href="https://example.org" custom-attribute="true">Link</a>
```

The proposed changes allow hyphens in the tag attributes regex so they are not ignored anymore.