### PR TITLE
Better formatting for lists

### DIFF
--- a/Sources/ZMarkupParser/Core/MarkupStyle/MarkupStyle.swift
+++ b/Sources/ZMarkupParser/Core/MarkupStyle/MarkupStyle.swift
@@ -42,8 +42,9 @@ public struct MarkupStyle: MarkupStyleItem {
     public var expansion:NSNumber? = nil
     public var writingDirection:NSNumber? = nil
     public var verticalGlyphForm:NSNumber? = nil
+    public var listStyle: MarkupStyleListStyle? = nil
     
-    public init(font: MarkupStyleFont = MarkupStyleFont(), fontCase: MarkupStyleFont.CaseStyle? = nil, paragraphStyle: MarkupStyleParagraphStyle = MarkupStyleParagraphStyle(), foregroundColor: MarkupStyleColor? = nil, backgroundColor: MarkupStyleColor? = nil, ligature: NSNumber? = nil, kern: NSNumber? = nil, tracking: NSNumber? = nil, strikethroughStyle: NSUnderlineStyle? = nil, underlineStyle: NSUnderlineStyle? = nil, strokeColor: MarkupStyleColor? = nil, strokeWidth: NSNumber? = nil, shadow: NSShadow? = nil, textEffect: String? = nil, attachment: NSTextAttachment? = nil, link: URL? = nil, baselineOffset: NSNumber? = nil, underlineColor: MarkupStyleColor? = nil, strikethroughColor: MarkupStyleColor? = nil, obliqueness: NSNumber? = nil, expansion: NSNumber? = nil, writingDirection: NSNumber? = nil, verticalGlyphForm: NSNumber? = nil) {
+    public init(font: MarkupStyleFont = MarkupStyleFont(), fontCase: MarkupStyleFont.CaseStyle? = nil, paragraphStyle: MarkupStyleParagraphStyle = MarkupStyleParagraphStyle(), foregroundColor: MarkupStyleColor? = nil, backgroundColor: MarkupStyleColor? = nil, ligature: NSNumber? = nil, kern: NSNumber? = nil, tracking: NSNumber? = nil, strikethroughStyle: NSUnderlineStyle? = nil, underlineStyle: NSUnderlineStyle? = nil, strokeColor: MarkupStyleColor? = nil, strokeWidth: NSNumber? = nil, shadow: NSShadow? = nil, textEffect: String? = nil, attachment: NSTextAttachment? = nil, link: URL? = nil, baselineOffset: NSNumber? = nil, underlineColor: MarkupStyleColor? = nil, strikethroughColor: MarkupStyleColor? = nil, obliqueness: NSNumber? = nil, expansion: NSNumber? = nil, writingDirection: NSNumber? = nil, verticalGlyphForm: NSNumber? = nil, listStyle: MarkupStyleListStyle? = nil) {
         self.font = font
         self.fontCase = fontCase
         self.paragraphStyle = paragraphStyle
@@ -67,6 +68,7 @@ public struct MarkupStyle: MarkupStyleItem {
         self.expansion = expansion
         self.writingDirection = writingDirection
         self.verticalGlyphForm = verticalGlyphForm
+        self.listStyle = listStyle
     }
     
     mutating func fillIfNil(from: MarkupStyle?) {
@@ -100,6 +102,7 @@ public struct MarkupStyle: MarkupStyleItem {
         self.expansion = self.expansion ?? from.expansion
         self.writingDirection = self.writingDirection ?? from.writingDirection
         self.verticalGlyphForm = self.verticalGlyphForm ?? from.verticalGlyphForm
+        self.listStyle = self.listStyle ?? from.listStyle
     }
     
     func isNil() -> Bool {
@@ -235,8 +238,9 @@ public struct MarkupStyle {
     public var spellingState:NSAttributedString.SpellingState? = nil
     public var superscript:NSNumber? = nil
     public var glyphInfo:NSGlyphInfo? = nil
+    public var listStyle: MarkupStyleListStyle? = nil
     
-    public init(font: MarkupStyleFont = MarkupStyleFont(), fontCase: MarkupStyleFont.CaseStyle? = nil, paragraphStyle: MarkupStyleParagraphStyle = MarkupStyleParagraphStyle(), foregroundColor: MarkupStyleColor? = nil, backgroundColor: MarkupStyleColor? = nil, ligature: NSNumber? = nil, kern: NSNumber? = nil, tracking: NSNumber? = nil, strikethroughStyle: NSUnderlineStyle? = nil, underlineStyle: NSUnderlineStyle? = nil, strokeColor: MarkupStyleColor? = nil, strokeWidth: NSNumber? = nil, shadow: NSShadow? = nil, textEffect: NSAttributedString.TextEffectStyle? = nil, attachment: NSTextAttachment? = nil, link: URL? = nil, baselineOffset: NSNumber? = nil, underlineColor: MarkupStyleColor? = nil, strikethroughColor: MarkupStyleColor? = nil, obliqueness: NSNumber? = nil, expansion: NSNumber? = nil, writingDirection: NSArray? = nil, verticalGlyphForm: NSNumber? = nil, cursor: NSCursor? = nil, toolTip: String? = nil, markedClauseSegment: NSNumber? = nil, textAlternatives: NSTextAlternatives? = nil, spellingState: NSAttributedString.SpellingState? = nil, superscript: NSNumber? = nil, glyphInfo: NSGlyphInfo? = nil) {
+    public init(font: MarkupStyleFont = MarkupStyleFont(), fontCase: MarkupStyleFont.CaseStyle? = nil, paragraphStyle: MarkupStyleParagraphStyle = MarkupStyleParagraphStyle(), foregroundColor: MarkupStyleColor? = nil, backgroundColor: MarkupStyleColor? = nil, ligature: NSNumber? = nil, kern: NSNumber? = nil, tracking: NSNumber? = nil, strikethroughStyle: NSUnderlineStyle? = nil, underlineStyle: NSUnderlineStyle? = nil, strokeColor: MarkupStyleColor? = nil, strokeWidth: NSNumber? = nil, shadow: NSShadow? = nil, textEffect: NSAttributedString.TextEffectStyle? = nil, attachment: NSTextAttachment? = nil, link: URL? = nil, baselineOffset: NSNumber? = nil, underlineColor: MarkupStyleColor? = nil, strikethroughColor: MarkupStyleColor? = nil, obliqueness: NSNumber? = nil, expansion: NSNumber? = nil, writingDirection: NSArray? = nil, verticalGlyphForm: NSNumber? = nil, cursor: NSCursor? = nil, toolTip: String? = nil, markedClauseSegment: NSNumber? = nil, textAlternatives: NSTextAlternatives? = nil, spellingState: NSAttributedString.SpellingState? = nil, superscript: NSNumber? = nil, glyphInfo: NSGlyphInfo? = nil, listStyle: MarkupStyleListStyle? = nil) {
         self.font = font
         self.fontCase = fontCase
         self.paragraphStyle = paragraphStyle
@@ -267,6 +271,7 @@ public struct MarkupStyle {
         self.spellingState = spellingState
         self.superscript = superscript
         self.glyphInfo = glyphInfo
+        self.listStyle = listStyle
     }
     
     mutating func fillIfNil(from: MarkupStyle?) {
@@ -308,6 +313,7 @@ public struct MarkupStyle {
         self.spellingState = self.spellingState ?? from.spellingState
         self.superscript = self.superscript ?? from.superscript
         self.glyphInfo = self.glyphInfo ?? from.glyphInfo
+        self.listStyle = self.listStyle ?? from.listStyle
     }
     
     func render() -> [NSAttributedString.Key: Any] {

--- a/Sources/ZMarkupParser/Core/MarkupStyle/MarkupStyleListStyle.swift
+++ b/Sources/ZMarkupParser/Core/MarkupStyle/MarkupStyleListStyle.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//  
+//
+//  Created by Lukas Gergel on 27.05.2024.
+//
+
+import Foundation
+
+public struct MarkupStyleListStyle: MarkupStyleItem {
+    public var listItemSpacing:CGFloat? = 4
+    public var listIndent:CGFloat? = 16
+    
+    public init(listItemSpacing: CGFloat? = nil, listIndent: CGFloat? = nil) {
+        self.listItemSpacing = listItemSpacing
+        self.listIndent = listIndent
+    }
+    
+    mutating func fillIfNil(from: MarkupStyleListStyle?) {
+        self.listItemSpacing = self.listItemSpacing ?? from?.listItemSpacing
+        self.listIndent = self.listIndent ?? from?.listIndent
+    }
+    
+    func isNil() -> Bool {
+        return !([listItemSpacing,listIndent] as [Any?]).contains(where: { $0 != nil})
+    }
+}


### PR DESCRIPTION
Added a new MarkupStyleListStyle that allows you to edit the list formatting options.

- adding spaces between bullet and text
- alignment of wrapped text to the beginning of the first line (with bullet).

example:
<img width="338" alt="Screenshot 2024-05-28 at 6 23 06" src="https://github.com/ZhgChgLi/ZMarkupParser/assets/1457377/d8941492-b6fc-4808-a30c-5994302fb51d">
