### PR TITLE
To verify a CocoaPod and a Swift Package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,18 @@ jobs:
         run: |
           set -o pipefail
           xcodebuild test -workspace ZMarkupParser.xcworkspace -testPlan UnitTest -scheme ZMarkupParser -enableCodeCoverage YES -resultBundlePath './scripts/TestResult.xcresult' -destination 'platform=iOS Simulator,name=iPhone 15,OS=17.0.1' build test | xcpretty
+
+      - name: "Build Swift Pacakge"
+        run: |
+          swift build
+            
+      - name: "Build CocoaPods"
+        env:
+          PODSPEC_PATH: scripts/ZMarkupParser.podspec
+        run: |
+          gem install cocoapods
+          pod lib lint --allow-warnings $PODSPEC_PATH
+          
       - name: Codecov
         uses: codecov/codecov-action@v3.1.1
         with:


### PR DESCRIPTION
The ci.yml has been set up to build and test ZMarkupParser.xcworkspace, but it does not guarantee compatibility with CocoaPods and Swift Package Manager.

The PR supports this.