### PR TITLE
feat: Swift AttributedString render API (v2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Full methodology and length-scaling table in [`PERF_REPORT.md`](./PERF_REPORT.md
 
 - File > Swift Packages > Add Package Dependency
 - Add `https://github.com/ZhgChgLi/ZMarkupParser.git`
-- Select "Up to Next Major" with "2.0.1"
+- Select "Up to Next Major" with "2.1.0"
 
 or 
 
 ```swift
 ...
 dependencies: [
-  .package(url: "https://github.com/ZhgChgLi/ZMarkupParser.git", from: "2.0.1"),
+  .package(url: "https://github.com/ZhgChgLi/ZMarkupParser.git", from: "2.1.0"),
 ]
 ...
 .target(
@@ -88,7 +88,7 @@ platform :ios, '12.0'
 use_frameworks!
 
 target 'MyApp' do
-  pod 'ZMarkupParser', '~> 2.0.1'
+  pod 'ZMarkupParser', '~> 2.1.0'
 end
 ```
 
@@ -323,6 +323,26 @@ textView.setHtmlString(htmlString)
 
 // work with UILabel
 label.setHtmlString(htmlString)
+```
+
+### SwiftUI / `AttributedString`
+The `AttributedString` overloads return Foundation's value-type [`AttributedString`](https://developer.apple.com/documentation/foundation/attributedstring) (iOS 15+ / macOS 12+) so SwiftUI's `Text` can render the parsed result directly. Available on iOS 15 / tvOS 15 / macOS 12 / watchOS 8 and up — the existing `NSAttributedString` API is unchanged on older OS targets.
+```swift
+import SwiftUI
+
+struct ContentView: View {
+    let parser = ZHTMLParserBuilder.initWithDefault().build()
+    let html = "Hello <b>world</b>, visit <a href=\"https://zhgchg.li\">my blog</a>."
+
+    var body: some View {
+        Text(parser.attributedString(html))
+    }
+}
+
+// or asynchronously, mirroring `render(_:completionHandler:)`
+parser.attributedString(html) { attributed in
+    // delivered on the main queue
+}
 ```
 
 ### Stripper HTML String

--- a/Sources/ZMarkupParser/HTML/ZHTMLParser+AttributedString.swift
+++ b/Sources/ZMarkupParser/HTML/ZHTMLParser+AttributedString.swift
@@ -1,0 +1,56 @@
+//
+//  ZHTMLParser+AttributedString.swift
+//
+//
+//  Bridges `ZHTMLParser`'s existing `NSAttributedString` rendering pipeline to
+//  Foundation's value-type `AttributedString` (iOS 15+ / macOS 12+), so SwiftUI
+//  callers can write `Text(parser.attributedString(html))` directly instead of
+//  hand-wrapping `AttributedString(parser.render(html))` everywhere.
+//
+//  Implementation note: this is a thin wrapper that calls the existing
+//  `render(_:)` family and feeds the result into `AttributedString.init(_:)`.
+//  Foundation's initialiser maps the standard attribute keys (font, color,
+//  link, underline, paragraph style, attachment, …) through its built-in
+//  Foundation / UIKit / AppKit / SwiftUI scopes — i.e. every attribute the
+//  parser actually emits — so a separate native `AttributedString` visitor
+//  isn't worth maintaining.
+//
+
+import Foundation
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+public extension ZHTMLParser {
+
+    func attributedString(_ string: String, forceDecodeHTMLEntities: Bool = true) -> AttributedString {
+        return AttributedString(self.render(string, forceDecodeHTMLEntities: forceDecodeHTMLEntities))
+    }
+
+    func attributedString(_ attributedString: NSAttributedString, forceDecodeHTMLEntities: Bool = true) -> AttributedString {
+        return AttributedString(self.render(attributedString, forceDecodeHTMLEntities: forceDecodeHTMLEntities))
+    }
+
+    func attributedString(_ selector: HTMLSelector) -> AttributedString {
+        return AttributedString(self.render(selector))
+    }
+
+    func attributedString(_ string: String, forceDecodeHTMLEntities: Bool = true, completionHandler: @escaping (AttributedString) -> Void) {
+        ZHTMLParser.dispatchQueue.async {
+            let result = self.attributedString(string, forceDecodeHTMLEntities: forceDecodeHTMLEntities)
+            DispatchQueue.main.async { completionHandler(result) }
+        }
+    }
+
+    func attributedString(_ attributedString: NSAttributedString, forceDecodeHTMLEntities: Bool = true, completionHandler: @escaping (AttributedString) -> Void) {
+        ZHTMLParser.dispatchQueue.async {
+            let result = self.attributedString(attributedString, forceDecodeHTMLEntities: forceDecodeHTMLEntities)
+            DispatchQueue.main.async { completionHandler(result) }
+        }
+    }
+
+    func attributedString(_ selector: HTMLSelector, completionHandler: @escaping (AttributedString) -> Void) {
+        ZHTMLParser.dispatchQueue.async {
+            let result = self.attributedString(selector)
+            DispatchQueue.main.async { completionHandler(result) }
+        }
+    }
+}

--- a/Tests/ZMarkupParserTests/HTML/ZHTMLParserAttributedStringTests.swift
+++ b/Tests/ZMarkupParserTests/HTML/ZHTMLParserAttributedStringTests.swift
@@ -1,0 +1,106 @@
+//
+//  ZHTMLParserAttributedStringTests.swift
+//
+//
+//  Covers `ZHTMLParser+AttributedString` — verifies that the
+//  `NSAttributedString` -> `AttributedString` wrapper preserves the parser's
+//  rendered text and the attributes SwiftUI / iOS 15+ consumers actually look
+//  at (link, font traits, paragraph style), and that the completion-handler
+//  variant returns on the main queue like the other `ZHTMLParser` async APIs.
+//
+
+import Foundation
+@testable import ZMarkupParser
+import XCTest
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+final class ZHTMLParserAttributedStringTests: XCTestCase {
+
+    private let parser = ZHTMLParserBuilder.initWithDefault().build()
+
+    func testAttributedStringPlainTextMatchesRender() {
+        let html = "Hello <b>bold</b> <i>italic</i> <a href=\"https://zhgchg.li\">link</a> end."
+        let viaWrapper = parser.attributedString(html)
+        let viaRender = parser.render(html)
+
+        XCTAssertEqual(String(viaWrapper.characters), viaRender.string)
+    }
+
+    func testAttributedStringPreservesLink() {
+        let html = "prefix <a href=\"https://zhgchg.li\">click here</a> suffix"
+        let attributed = parser.attributedString(html)
+
+        var collectedURL: URL?
+        for run in attributed.runs {
+            if let link = run.link {
+                collectedURL = link
+                break
+            }
+        }
+        XCTAssertEqual(collectedURL, URL(string: "https://zhgchg.li"))
+    }
+
+    func testAttributedStringPreservesBoldFontTrait() {
+        let html = "normal <b>strong</b> normal"
+        let attributed = parser.attributedString(html)
+        let plain = String(attributed.characters)
+        guard let boldStart = plain.range(of: "strong") else {
+            return XCTFail("expected 'strong' in rendered output, got: \(plain)")
+        }
+
+        // Find the run that contains the "strong" range and assert its font is bold.
+        let lower = AttributedString.Index(boldStart.lowerBound, within: attributed)!
+        let runAtBold = attributed.runs[lower]
+        #if canImport(UIKit)
+        guard let font = runAtBold.uiKit.font else {
+            return XCTFail("expected a UIFont on the bold run")
+        }
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.traitBold), "<b> run should carry a bold UIFont; got \(font)")
+        #elseif canImport(AppKit)
+        guard let font = runAtBold.appKit.font else {
+            return XCTFail("expected an NSFont on the bold run")
+        }
+        XCTAssertTrue(font.fontDescriptor.symbolicTraits.contains(.bold), "<b> run should carry a bold NSFont; got \(font)")
+        #endif
+    }
+
+    func testAttributedStringCompletionHandlerInvokedOnMain() {
+        let html = "Test<a href=\"https://zhgchg.li\">Qoo</a>DDD"
+        let referencePlain = String(parser.attributedString(html).characters)
+
+        let expectation = XCTestExpectation(description: #function)
+        parser.attributedString(html) { result in
+            XCTAssertTrue(Thread.isMainThread, "completion handler must fire on the main queue, mirroring render(_:completionHandler:)")
+            XCTAssertEqual(String(result.characters), referencePlain)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 3.0)
+    }
+
+    func testAttributedStringFromNSAttributedStringInputMatchesRender() {
+        let attributed = NSAttributedString(string: "Test<a href=\"https://zhgchg.li\">Qoo</a>DDD", attributes: [.kern: 5])
+        let viaWrapper = parser.attributedString(attributed)
+        let viaRender = parser.render(attributed)
+
+        XCTAssertEqual(String(viaWrapper.characters), viaRender.string)
+    }
+
+    func testAttributedStringFromSelectorMatchesRender() {
+        let html = "Test<a href=\"https://zhgchg.li\">Q<b>fa</b>foo</a>DDD"
+        let selector = parser.selector(html)
+        guard let anchor = selector.first("a") else {
+            return XCTFail("expected to find <a> in selector")
+        }
+
+        let viaWrapper = parser.attributedString(anchor)
+        let viaRender = parser.render(anchor)
+
+        XCTAssertEqual(String(viaWrapper.characters), viaRender.string)
+    }
+}

--- a/scripts/ZMarkupParser.podspec
+++ b/scripts/ZMarkupParser.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ZMarkupParser"
-  s.version          = "2.0.1"
+  s.version          = "2.1.0"
   s.summary          = "ZMarkupParser helps you to convert HTML String to NSAttributedString with customized style and tag through pure-Swift."
   s.homepage         = "https://github.com/ZhgChgLi/ZMarkupParser"
   s.license          = { :type => "MIT", :file => "LICENSE" }


### PR DESCRIPTION
## Summary
- Adds `parser.attributedString(_:)` overloads that return Foundation's value-type [`AttributedString`](https://developer.apple.com/documentation/foundation/attributedstring) (iOS 15+ / macOS 12+).
- SwiftUI consumers can drop `AttributedString(parser.render(html))` boilerplate and write `Text(parser.attributedString(html))` directly.
- `NSAttributedString` API is **unchanged** — this is a parallel surface gated behind `@available(iOS 15, tvOS 15, macOS 12, watchOS 8, *)`. Package's iOS 12 / macOS 10.14 minimum target is untouched.

## API (mirrors `render(_:)` shape, sync + completion handler)
```swift
@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
public extension ZHTMLParser {
    func attributedString(_ string: String, forceDecodeHTMLEntities: Bool = true) -> AttributedString
    func attributedString(_ attributedString: NSAttributedString, forceDecodeHTMLEntities: Bool = true) -> AttributedString
    func attributedString(_ selector: HTMLSelector) -> AttributedString

    func attributedString(_ string: String, forceDecodeHTMLEntities: Bool = true, completionHandler: @escaping (AttributedString) -> Void)
    func attributedString(_ attributedString: NSAttributedString, forceDecodeHTMLEntities: Bool = true, completionHandler: @escaping (AttributedString) -> Void)
    func attributedString(_ selector: HTMLSelector, completionHandler: @escaping (AttributedString) -> Void)
}
```

Naming follows the existing noun-style of `selector(_:)` / `stripper(_:)`. Can't overload `render(_:) -> AttributedString` because Swift won't disambiguate by return type alone.

## Implementation
Thin wrapper: each method calls the existing `render(_:)` path and feeds the resulting `NSAttributedString` into `AttributedString.init(_:)`. Foundation's initialiser maps the standard keys (font, color, link, underline, paragraph style, attachment, …) through the built-in Foundation / UIKit / AppKit / SwiftUI scopes — covering every attribute ZMarkupParser actually emits. Image attachments via ZNSTextAttachment carry through as `NSTextAttachment` subclasses. Total wrapper code ~50 lines.

## Files changed
- `Sources/ZMarkupParser/HTML/ZHTMLParser+AttributedString.swift` *(new, ~55 lines)* — the 6 public overloads.
- `Tests/ZMarkupParserTests/HTML/ZHTMLParserAttributedStringTests.swift` *(new, ~100 lines)* — plain-text equivalence vs `render(_:)`, link preservation, bold font-trait preservation (UIKit + AppKit), main-queue completion handler, NSAttributedString-input + HTMLSelector-input round-trips.
- `README.md` — adds a SwiftUI / `AttributedString` section under Render; bumps installation hints to 2.1.0.
- `scripts/ZMarkupParser.podspec` — `s.version` 2.0.1 → 2.1.0.

## Compatibility
- **No breaking changes.** Every existing API is unchanged.
- **Older OS targets (iOS 12 / macOS 10.14) keep working** — the new methods are simply unavailable below their `@available` floor. Building against iOS 14 etc. is unaffected.

## Test plan
- [x] `swift test` — 92 tests pass on macOS (86 existing + 6 new).
- [ ] CI: iOS snapshot tests on Xcode 26.2 / iPhone 17 Pro Simulator must remain green (this PR doesn't touch the existing render pipeline).
- [ ] Manual: drop `Text(parser.attributedString(html))` into a SwiftUI playground / Demo screen and confirm font, link, bold, italic render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)